### PR TITLE
Fix Windows MSVC support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,9 @@ In your build script, assuming the crate's name is "checksums" and the resource 
 extern crate embed_resource;
 
 fn main() {
-    // Compile file checksums.rc to be linkable as checksums-manifest in $OUT_DIR
-    embed_resource::compile("checksums.rc", None, None);
+    // Compile and link checksums.rc
+    embed_resource::compile("checksums.rc");
 }
-```
-
-Then, in `main.rs`:
-
-```rust
-#[cfg(target_os="windows")]
-#[link(name="checksums-manifest", kind="static")]
-extern "C" {}
-```
-
-If you want to link as something else (like `chksum-rc`):
-
-```rust
-embed_resource::compile("checksums.rc", Some("chksum-rc"), None);
-```
-
-```rust
-#[cfg(target_os="windows")]
-#[link(name="chksum-rc", kind="static")]
-extern "C" {}
 ```
 
 ## Credit
@@ -48,3 +28,5 @@ In chronological order:
 [@TheCatPlusPlus](https://github.com/TheCatPlusPlus) -- knowledge and providing first iteration of manifest-embedding code
 
 [@azyobuzin](https://github.com/azyobuzin) -- providing code for finding places where RC.EXE could hide
+
+[@retep998](https://github.com/retep998) -- fixing MSVC support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,23 +2,24 @@ version: 1.0.1-{build}
 
 skip_tags: false
 
-platform: x64
-configuration: Release
-
 clone_folder: C:\rust-embed-resource
 
-install:
-  - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
-  - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
-  - bash -lc "pacman --noconfirm -Sy"
-  - bash -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain"
-  -
-  - curl -SL https://win.rustup.rs/ -oC:\rustup-init.exe
-  - C:\rustup-init.exe -y --default-host="x86_64-pc-windows-gnu"
+environment:
+  matrix:
+    - TARGET: x86_64-pc-windows-gnu
+      MINGW: true
+    - TARGET: x86_64-pc-windows-msvc
 
-build: off
+install:
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if defined MINGW set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
+  - if defined MINGW bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+  - if defined MINGW bash -lc "pacman --noconfirm -Sy"
+  - if defined MINGW bash -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain"
+  - curl -SL https://win.rustup.rs/ -oC:\rustup-init.exe
+  - C:\rustup-init.exe -y --default-host="%TARGET%"
+
 build_script:
-  - git submodule update --init --recursive
   - cargo build --verbose --release
 
 notifications:

--- a/src/windows_msvc.rs
+++ b/src/windows_msvc.rs
@@ -2,11 +2,11 @@ use std::path::{PathBuf, Path};
 use std::process::Command;
 use winreg::enums::*;
 use std::env;
-
+use winreg;
 
 pub const SUPPORTED: bool = true;
 
-#[derive(Clone, Hash, Copy, Eq, PartialEq, Cmp, PartialCmp)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 enum Arch {
     X86,
     X64,

--- a/src/windows_not_msvc.rs
+++ b/src/windows_not_msvc.rs
@@ -1,19 +1,11 @@
 use std::process::Command;
-use std::path::Path;
-
 
 pub const SUPPORTED: bool = true;
 
 pub fn compile_resource(out_dir: &str, prefix: &str, resource: &str) {
     Command::new("windres")
         .args(&["--input", resource, "--output-format=coff", "--output"])
-        .arg(&format!("{}/{}.res", out_dir, prefix))
-        .status()
-        .unwrap();
-
-    Command::new("ar")
-        .args(&["crs", &format!("lib{}.a", prefix), &format!("{}.res", prefix)])
-        .current_dir(&Path::new(&out_dir))
+        .arg(&format!("{}/lib{}.a", out_dir, prefix))
         .status()
         .unwrap();
 }


### PR DESCRIPTION
Yes, I tested this. Yes, it works.
Also I simplified the API because there's really no reason for the user to customize the naming or directories.
Also made Appveyor test both MSVC and GNU on Windows.