### PR TITLE
Update to winreg 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ exclude = ["*.enc"]
 vswhom = "0.1.0"
 
 [target.'cfg(all(target_os = "windows", target_env = "msvc"))'.dependencies.winreg]
-version = "0.5"
+version = "0.6"
 default-features = false


### PR DESCRIPTION
Updated `winreg` dependency from 0.5 to 0.6. No changes needed.