### PR TITLE
Add windows manifest embed example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,48 @@ fn main() {
 }
 ```
 
+## Example: Embedding a Windows Manifest
+
+The following steps are used to embed a manifest in your compiled rust .exe file. In this example the manifest will cause admin permissions to be requested for the final executable:
+
+1) Add the following to your cargo.toml:
+```
+[build-dependencies]
+embed-resource = "1.3"
+```
+
+2) In your project root directory, add a file named `build.rs` with the following:
+```
+extern crate embed_resource;
+fn main() {
+    embed_resource::compile("app-name-manifest.rc");
+}
+```
+
+3) In your project root directory, add a file named `app-name-manifest.rc` with the following:
+```
+#define RT_MANIFEST 24
+1 RT_MANIFEST "app-name.exe.manifest"
+```
+
+4) In your project root directory, add a file named `app-name.exe.manifest` with the following:
+
+```
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+</assembly>
+```
+
+5) Build your project!
+
+
 ## Credit
 
 In chronological order:


### PR DESCRIPTION
This PR simply adds an example to the README to illustrate to users how the functionality of this crate might be applied. These instructions relate to the embedding a windows manifest as described in #15.