### PR TITLE
Add automatic include support for Windows 10 SDKs

### DIFF
--- a/src/windows_msvc.rs
+++ b/src/windows_msvc.rs
@@ -1,5 +1,6 @@
 use std::path::{PathBuf, Path};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 use vswhom::VsFindResult;
 use winreg::enums::*;
 use std::{env, fs};
@@ -103,10 +104,12 @@ fn find_latest_windows_sdk_rc_exe(arch: Arch) -> Option<PathBuf> {
 
 // Windows 10 with subdir support
 fn find_windows_10_kits_rc_exe(key: &str, arch: Arch) -> Option<PathBuf> {
-    let root_dir = (winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
+    let kit_root = (winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
         .open_subkey_with_flags(r"SOFTWARE\Microsoft\Windows Kits\Installed Roots", KEY_QUERY_VALUE)
         .and_then(|reg_key| reg_key.get_value::<String, _>(key))
-        .ok())? + "/bin";
+        .ok())?;
+    include_windows_10_kits(&kit_root);
+    let root_dir = kit_root + "/bin";
 
     for entry in fs::read_dir(&root_dir).ok()?.filter(|d| d.is_ok()).map(Result::unwrap) {
         let fname = entry.file_name().into_string();
@@ -122,6 +125,38 @@ fn find_windows_10_kits_rc_exe(key: &str, arch: Arch) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn include_windows_10_kits(kit_root: &str) {
+    static IS_INCLUDED: AtomicBool = AtomicBool::new(false);
+
+    if !IS_INCLUDED.swap(true, SeqCst) {
+        include_impl(kit_root);
+    }
+}
+
+fn include_impl(kit_root: &str) {
+    const VAR_INCLUDE: &str = "INCLUDE";
+
+    if let Ok(include_root) = fs::read_dir(kit_root.to_owned() + r"\Include\") {
+        let mut include = env::var(VAR_INCLUDE).unwrap_or_else(|_| String::new());
+        if !include.ends_with(';') {
+            include.push(';');
+        }
+        get_dirs(include_root).filter_map(|dir| fs::read_dir(dir.path()).ok()).for_each(|dir|
+            get_dirs(dir).for_each(|sub_dir| if let Some(sub_dir) = sub_dir.path().to_str() {
+                if !include.contains(sub_dir) {
+                    include.push_str(sub_dir);
+                    include.push(';');
+                }
+            })
+        );
+        env::set_var(VAR_INCLUDE, include);
+    }
+}
+
+fn get_dirs(read_dir: fs::ReadDir) -> impl Iterator<Item=fs::DirEntry> {
+    read_dir.filter_map(|dir| dir.ok()).filter(|dir| dir.file_type().map_or(false, |ft| ft.is_dir()))
 }
 
 fn try_bin_dir<R: Into<PathBuf>>(root_dir: R, x86_bin: &str, x64_bin: &str, arch: Arch) -> Option<PathBuf> {


### PR DESCRIPTION
This should fix #11 for all version 10 SDKs by adding all `\Include\<version>\` sub-folders to `INCLUDE` env variable before running `rc.exe`.