### PR TITLE
expose tool finding mechanism in public api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,6 @@ fn compile_impl(resource_file: &Path) {
 ///
 /// This will try its hardest to find tools such as `MIDL.EXE` in Windows Kits and/or SDK directories.
 /// The compilers and linkers can be better found with the `cc` or `vswhom` crates.
-pub fn find_tool<T: AsRef<str>>(tool: T) -> Option<PathBuf> {
-    find_windows_sdk_tool(tool.as_ref())
+pub fn find_windows_sdk_tool<T: AsRef<str>>(tool: T) -> Option<PathBuf> {
+    find_windows_sdk_tool_impl(tool.as_ref())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ use self::windows_msvc::*;
 use self::windows_not_msvc::*;
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 
 /// Compile the Windows resource file and update the cargo search path if we're on Windows.
@@ -132,4 +132,12 @@ fn compile_impl(resource_file: &Path) {
         println!("cargo:rustc-link-search=native={}", out_dir);
         println!("cargo:rustc-link-lib=dylib={}", prefix);
     }
+}
+
+/// Find build tools other than the compiler and linker.
+///
+/// This will try its hardest to find tools such as `MIDL.EXE` in Windows Kits and/or SDK directories.
+/// The compilers and linkers can be better found with the `cc` or `vswhom` crates.
+pub fn find_tool<T: AsRef<str>>(tool: T) -> Option<PathBuf> {
+    find_windows_sdk_tool(tool.as_ref())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,32 +134,37 @@ fn compile_impl(resource_file: &Path) {
     }
 }
 
-/// Find build tools other than the compiler and linker.
+
+/// Find MSVC build tools other than the compiler and linker
 ///
-/// On MSVC Windows this can be used try to find tools such as `MIDL.EXE` in Windows Kits and/or SDK directories.
-/// The compilers and linkers can be better found with the `cc` or `vswhom` crates. This will return `None`
-/// for non MSVC targets.
+/// On Windows + MSVC this can be used try to find tools such as `MIDL.EXE` in Windows Kits and/or SDK directories.
+///
+/// The compilers and linkers can be better found with the `cc` or `vswhom` crates.
+/// This always returns `None` on non-MSVC targets.
+///
 /// # Examples
 ///
 /// In your build script, find `midl.exe` and use it to compile an IDL file:
 ///
 /// ```rust,no_run
-/// use std::env;
-/// use std::process::Command;
+/// # #[cfg(all(target_os = "windows", target_env = "msvc"))]
+/// # {
+/// extern crate embed_resource;
+/// extern crate vswhom;
+/// # use std::env;
+/// # use std::process::Command;
 ///
 /// let midl = embed_resource::find_windows_sdk_tool("midl.exe").unwrap();
-/// let mut command = Command::new(midl);
-/// // midl.exe uses cl.exe as a preprocessor, so add it to the path
+///
+/// // midl.exe uses cl.exe as a preprocessor, so it needs to be in PATH
 /// let vs_locations = vswhom::VsFindResult::search().unwrap();
-/// command.env("PATH", vs_locations.vs_exe_path.unwrap());
+/// let output = Command::new(midl)
+///     .env("PATH", vs_locations.vs_exe_path.unwrap())
+///     .args(&["/out", &env::var("OUT_DIR").unwrap()])
+///     .arg("haka.pfx.idl").output().unwrap();
 ///
-/// let out_dir = env::var("OUT_DIR").unwrap();
-/// command.args(&["/out", &out_dir]);
-///
-/// command.arg("haka.pfx.idl");
-/// 
-/// let output = command.output().unwrap();
 /// assert!(output.status.success());
+/// # }
 /// ```
 pub fn find_windows_sdk_tool<T: AsRef<str>>(tool: T) -> Option<PathBuf> {
     find_windows_sdk_tool_impl(tool.as_ref())

--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 use std::env;
 
@@ -38,3 +39,6 @@ fn get_windres_executable() -> Option<&'static str> {
         _ => None,
     }
 }
+
+
+pub(crate) fn find_windows_sdk_tool(_tool: &str) -> Option<PathBuf> { None }

--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -41,4 +41,4 @@ fn get_windres_executable() -> Option<&'static str> {
 }
 
 
-pub(crate) fn find_windows_sdk_tool(_tool: &str) -> Option<PathBuf> { None }
+pub(crate) fn find_windows_sdk_tool_impl(_tool: &str) -> Option<PathBuf> { None }

--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::process::Command;
+use std::path::PathBuf;
 use std::env;
 
 
@@ -41,4 +41,6 @@ fn get_windres_executable() -> Option<&'static str> {
 }
 
 
-pub(crate) fn find_windows_sdk_tool_impl(_tool: &str) -> Option<PathBuf> { None }
+pub fn find_windows_sdk_tool_impl(_: &str) -> Option<PathBuf> {
+    None
+}

--- a/src/windows_msvc.rs
+++ b/src/windows_msvc.rs
@@ -25,7 +25,7 @@ impl ResourceCompiler {
 
     pub fn compile_resource(&self, out_dir: &str, prefix: &str, resource: &str) {
         // `.res`es are linkable under MSVC as well as normal libraries.
-        if !Command::new(find_windows_sdk_tool("rc.exe").as_ref().map_or(Path::new("rc.exe"), Path::new))
+        if !Command::new(find_windows_sdk_tool_impl("rc.exe").as_ref().map_or(Path::new("rc.exe"), Path::new))
             .args(&["/fo", &format!("{}/{}.lib", out_dir, prefix), resource])
             .status()
             .expect("Are you sure you have RC.EXE in your $PATH?")
@@ -42,7 +42,7 @@ enum Arch {
     X64,
 }
 
-pub(crate) fn find_windows_sdk_tool(tool: &str) -> Option<PathBuf> {
+pub(crate) fn find_windows_sdk_tool_impl(tool: &str) -> Option<PathBuf> {
     let arch = if env::var("TARGET").expect("No TARGET env var").starts_with("x86_64") {
         Arch::X64
     } else {

--- a/src/windows_msvc.rs
+++ b/src/windows_msvc.rs
@@ -42,7 +42,7 @@ enum Arch {
     X64,
 }
 
-pub(crate) fn find_windows_sdk_tool_impl(tool: &str) -> Option<PathBuf> {
+pub fn find_windows_sdk_tool_impl(tool: &str) -> Option<PathBuf> {
     let arch = if env::var("TARGET").expect("No TARGET env var").starts_with("x86_64") {
         Arch::X64
     } else {
@@ -56,6 +56,7 @@ pub(crate) fn find_windows_sdk_tool_impl(tool: &str) -> Option<PathBuf> {
         .or_else(|| find_windows_10_kits_tool("KitsRoot10", arch, tool))
         .or_else(|| find_with_vswhom(arch, tool))
 }
+
 
 fn find_with_vswhom(arch: Arch, tool: &str) -> Option<PathBuf> {
     let res = VsFindResult::search();
@@ -120,7 +121,7 @@ fn find_windows_10_kits_tool(key: &str, arch: Arch, tool: &str) -> Option<PathBu
         }
 
         let fname = entry.file_name().into_string().unwrap();
-        if let Some(rc) = try_bin_dir(root_dir.clone(), &format!("{}/x86", fname), &format!("{}/x64", fname), arch).and_then(|pb | try_tool(pb, tool)) {
+        if let Some(rc) = try_bin_dir(root_dir.clone(), &format!("{}/x86", fname), &format!("{}/x64", fname), arch).and_then(|pb| try_tool(pb, tool)) {
             return Some(rc);
         }
     }
@@ -183,7 +184,6 @@ fn try_bin_dir_impl(mut root_dir: PathBuf, x86_bin: &str, x64_bin: &str, arch: A
 }
 
 fn try_tool(mut pb: PathBuf, tool: &str) -> Option<PathBuf> {
-    let tool = tool.to_string();
-    pb.push(&tool);
-    if pb.exists() { Some(pb) } else { None }   
+    pb.push(tool);
+    if pb.exists() { Some(pb) } else { None }
 }

--- a/src/windows_not_msvc.rs
+++ b/src/windows_not_msvc.rs
@@ -28,4 +28,4 @@ impl ResourceCompiler {
 }
 
 
-pub(crate) fn find_windows_sdk_tool(_tool: &str) -> Option<PathBuf> { None }
+pub(crate) fn find_windows_sdk_tool_impl(_tool: &str) -> Option<PathBuf> { None }

--- a/src/windows_not_msvc.rs
+++ b/src/windows_not_msvc.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 
@@ -25,3 +26,6 @@ impl ResourceCompiler {
         }
     }
 }
+
+
+pub(crate) fn find_windows_sdk_tool(_tool: &str) -> Option<PathBuf> { None }

--- a/src/windows_not_msvc.rs
+++ b/src/windows_not_msvc.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::process::Command;
+use std::path::PathBuf;
 
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -28,4 +28,6 @@ impl ResourceCompiler {
 }
 
 
-pub(crate) fn find_windows_sdk_tool_impl(_tool: &str) -> Option<PathBuf> { None }
+pub fn find_windows_sdk_tool_impl(_: &str) -> Option<PathBuf> {
+    None
+}


### PR DESCRIPTION
This is an implementation of what I was suggesting in https://github.com/nabijaczleweli/rust-embed-resource/issues/23.

There are a lot of other tools that are hard to find in the same way `rc.exe` is. In my case I need the same logic for `midl.exe`.

This should build for non `windows-msvc` targets and return no path, which seems consistent with the internal behavior of `find_windows_sdk_tool`.

I realize this might be out of scope or otherwise uninteresting. Thanks for taking the time to consider it, and thanks for `embed-resource`, it could hardly be more convenient.

