### PR TITLE
LLVM-RC support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ authors = ["nabijaczleweli <nabijaczleweli@gmail.com>",
            "Jim McGrath <jimmc2@gmail.com>"]
 exclude = ["*.enc"]
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+cc = "1.0.66"
 
 [target.'cfg(all(target_os = "windows", target_env = "msvc"))'.dependencies]
 vswhom = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ authors = ["nabijaczleweli <nabijaczleweli@gmail.com>",
            "Jim McGrath <jimmc2@gmail.com>"]
 exclude = ["*.enc"]
 
+
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-cc = "1.0.66"
+cc = "1.0"
 
 [target.'cfg(all(target_os = "windows", target_env = "msvc"))'.dependencies]
 vswhom = "0.1"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ fn main() {
 
 5. Build your project!
 
+## Cross-compilation
+
+It is possible to use this crate to embed resources in a windows executable
+compiled from linux. There are two ways to do this:
+
+- When targeting windows-gnu, make sure you have `x86_64-w64-mingw32-windres`
+  installed.
+- When targeting windows-msvc, you'll need to have `llvm-rc` installed and set
+  the `x86_64_pc_windows_msvc_RC` environment variable to it. Furthermore,
+  you'll also need to set the `x86_64_pc_windows_msvc_CPP` environment variable
+  to a C preprocessor set up to find the proper windows includes.
+
 ## Credit
 
 In chronological order:

--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ compiled from linux. There are two ways to do this:
   installed.
 - When targeting windows-msvc, you'll need to have `llvm-rc` installed and set
   the `x86_64_pc_windows_msvc_RC` environment variable to it. Furthermore,
-  you'll also need to set the `x86_64_pc_windows_msvc_CPP` environment variable
-  to a C preprocessor set up to find the proper windows includes.
+  the cc crate is used to preprocess the file. See the [cc crate] for
+  documentation on how to set up. If your resource file includes standard
+  windows headers like `winver.h`, the CC crate will need to be set up with a C
+  compiler that knows where to find those headers.
+
+[cc crate]: https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -58,22 +58,6 @@ fn main() {
 
 5. Build your project!
 
-## Cross-compilation
-
-It is possible to use this crate to embed resources in a windows executable
-compiled from linux. There are two ways to do this:
-
-- When targeting windows-gnu, make sure you have `x86_64-w64-mingw32-windres`
-  installed.
-- When targeting windows-msvc, you'll need to have `llvm-rc` installed and set
-  the `x86_64_pc_windows_msvc_RC` environment variable to it. Furthermore,
-  the cc crate is used to preprocess the file. See the [cc crate] for
-  documentation on how to set up. If your resource file includes standard
-  windows headers like `winver.h`, the CC crate will need to be set up with a C
-  compiler that knows where to find those headers.
-
-[cc crate]: https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables
-
 ## Credit
 
 In chronological order:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,16 @@
 //! }
 //! ```
 //!
+//! # Cross-compilation
+//!
+//! It is possible to embed resources in Windows executables built on non-Windows hosts. There are two ways to do this:
+//!
+//! When targetting `*-pc-windows-gnu`, `*-w64-mingw32-windres` is attempted by default, for `*-pc-windows-msvc` it's `llvm-rc`,
+//! this can be overriden by setting `RC_$TARGET`, `RC_${TARGET//-/_}`, or `RC` environment variables.
+//!
+//! When compiling with LLVM-RC, an external C compiler is used to preprocess the resource,
+//! preloaded with configuration from [`cc`](https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables).
+//!
 //! # Credit
 //!
 //! In chronological order:
@@ -74,6 +84,8 @@
 //!   * ThePhD
 
 
+#[cfg(not(target_os = "windows"))]
+extern crate cc;
 #[cfg(all(target_os = "windows", target_env = "msvc"))]
 extern crate vswhom;
 #[cfg(all(target_os = "windows", target_env = "msvc"))]

--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -2,44 +2,143 @@ use std::process::Command;
 use std::path::PathBuf;
 use std::env;
 
+#[derive(Debug, Clone)]
+enum ToolKind {
+    /// LLVM-rc. Note that LLVM-RC requires a separate C preprocessor to
+    /// preprocess the rc file.
+    LlvmRc { cpp: String, rc: String },
+    /// MinGW windres.
+    WindRes { exec: String },
+}
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone)]
 pub struct ResourceCompiler {
-    windres: Option<&'static str>,
+    tool: Option<ToolKind>,
 }
 
 
 impl ResourceCompiler {
     pub fn new() -> ResourceCompiler {
-        ResourceCompiler { windres: get_windres_executable() }
+        ResourceCompiler { tool: find_rc_tool() }
     }
 
     #[inline]
     pub fn is_supported(&self) -> bool {
-        self.windres.is_some()
+        match std::env::var("TARGET").as_deref() {
+            Ok("x86_64-pc-windows-msvc") => true,
+            Ok("i686-pc-windows-msvc") => true,
+            Ok("x86_64-pc-windows-gnu") => true,
+            Ok("i686-pc-windows-gnu") => true,
+            _ => false,
+        }
     }
 
     pub fn compile_resource(&self, out_dir: &str, prefix: &str, resource: &str) {
-        let windres = self.windres.expect("Couldn't find windres for this platform");
+        let kind = self.tool.as_ref().expect("Couldn't find windres or llvm-rc. Make sure one of them is in your $PATH.");
 
-        let out_file = format!("{}/lib{}.a", out_dir, prefix);
-        match Command::new(windres).args(&["--input", resource, "--output-format=coff", "--output", &out_file]).status() {
-            Ok(stat) if stat.success() => {}
-            Ok(stat) => panic!("{} failed to compile \"{}\" into \"{}\" with {}", windres, resource, out_file, stat),
-            Err(e) => panic!("Couldn't to execute {} to compile \"{}\" into \"{}\": {}", windres, resource, out_file, e),
+        match kind {
+           ToolKind::WindRes { exec } => compile_windres(&exec, out_dir, prefix, resource),
+           ToolKind::LlvmRc { rc, cpp } => compile_llvm_rc(&cpp, &rc, out_dir, prefix, resource),
         }
     }
 }
 
-
-fn get_windres_executable() -> Option<&'static str> {
-    match &env::var("TARGET").ok()?[..] {
-        "x86_64-pc-windows-gnu" => Some("x86_64-w64-mingw32-windres"),
-        "i686-pc-windows-gnu" => Some("i686-w64-mingw32-windres"),
-        _ => None,
+fn compile_llvm_rc(cpp_exec: &str, rc_exec: &str, out_dir: &str, prefix: &str, resource: &str) {
+    // First, we have to run cpp on the resource file as it doesn't
+    if !Command::new(cpp_exec)
+        .arg("-DRC_INVOKED")
+        .args(&["-o", &format!("{}/{}.preprocessed.rc", out_dir, prefix)])
+        .arg(resource)
+        .status()
+        .expect(&format!("Are you sure you have {} in your $PATH?", cpp_exec))
+        .success()
+    {
+        panic!("C preprocessor failed to handle specified resource file.")
+    }
+    if !Command::new(rc_exec)
+        .args(&["/fo", &format!("{}/{}.lib", out_dir, prefix)])
+        .arg(format!("{}/{}.preprocessed.rc", out_dir, prefix))
+        .status()
+        .expect("Are you sure you have llvm-rc in your $PATH?")
+        .success()
+    {
+        panic!("llvm-rc failed to compile specified resource file");
     }
 }
 
+fn compile_windres(exec: &str, out_dir: &str, prefix: &str, resource: &str) {
+    let out_file = format!("{}/lib{}.a", out_dir, prefix);
+    match Command::new(exec).args(&["--input", resource, "--output-format=coff", "--output", &out_file]).status() {
+        Ok(stat) if stat.success() => {}
+        Ok(stat) => panic!("{} failed to compile \"{}\" into \"{}\" with {}", exec, resource, out_file, stat),
+        Err(e) => panic!("Couldn't to execute {} to compile \"{}\" into \"{}\": {}", exec, resource, out_file, e),
+    }
+}
+
+fn command_exists(s: &str) -> bool {
+    match Command::new(s).spawn() {
+        Ok(mut v) => { let _ = v.kill(); true },
+        Err(err) => false,
+    }
+}
+
+fn detect_tool_kind(s: &str) -> ToolKind {
+    // -V will print the version in windres. /? will print the help in llvm-rc
+    // and microsoft rc. They can be combined, /? takes precedence over -V.
+    let out = match Command::new(s).args(&["-V", "/?"]).output() {
+        Ok(v) => v,
+        Err(err) => panic!("Failed to run {}: {}", s, err)
+    };
+
+    if out.stdout.starts_with(b"GNU windres") {
+        ToolKind::WindRes { exec: s.into() }
+    } else if out.stdout.starts_with(b"OVERVIEW: Resource Converter") {
+        let cpp = match get_var("CPP") {
+            Some(v) => v,
+            None => panic!("You must specify a C preprocessor in the CPP environment variable when using llvm-rc."),
+        };
+        ToolKind::LlvmRc { rc: s.into(), cpp }
+    } else {
+        panic!("Unknown RC program version found at path: {}", s)
+    }
+}
+
+fn find_rc_tool() -> Option<ToolKind> {
+    let target = std::env::var("TARGET").ok()?;
+
+    // If there's an RC binary explicitly set in an environment variable, use
+    // that.
+    if let Some(rc) = get_var("RC") {
+        let kind = detect_tool_kind(&rc);
+        return Some(kind)
+    }
+
+    // Otherwise, try to autodetect based on target.
+    if target == "x86_64-pc-windows-gnu" && command_exists("x86_64-w64-mingw32-windres") {
+        Some(ToolKind::WindRes { exec: "x86_64-w64-mingw32-windres".into() })
+    } else if target == "i686-pc-windows-gnu" && command_exists("i686-w64-mingw32-windres") {
+        Some(ToolKind::WindRes { exec: "i686-w64-mingw32-windres".into() })
+    } else {
+        None
+    }
+}
+
+
+/// Get a target-specific environment variable based on the passed value. This
+/// is used to find the appropriate tool for a given target: When
+/// cross-compiling to windows `x86_64-pc-windows-msvc`, we will look for
+/// environments variables like `x86_64-pc-windows-msvc_RC`
+fn get_var(var_base: &str) -> Option<String> {
+    let target = std::env::var("TARGET").unwrap();
+    let host = std::env::var("HOST").unwrap();
+    let kind = if host == target { "HOST" } else { "TARGET" };
+    let target_u = target.replace("-", "_");
+    std::env::var(&format!("{}_{}", var_base, target))
+        .or_else(|_| std::env::var(&format!("{}_{}", var_base, target_u)))
+        .or_else(|_| std::env::var(&format!("{}_{}", kind, var_base)))
+        .or_else(|_| std::env::var(var_base))
+        .ok()
+}
 
 pub fn find_windows_sdk_tool_impl(_: &str) -> Option<PathBuf> {
     None

--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -1,5 +1,5 @@
 use std::process::{Command, Stdio};
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 
 #[derive(Debug, Clone)]
 enum ToolKind {
@@ -50,6 +50,8 @@ fn compile_llvm_rc(rc_exec: &str, out_dir: &str, prefix: &str, resource: &str) {
         .cargo_metadata(false)
         .expand();
 
+    let resource_dir = Path::new(resource).parent().unwrap();
+
     let out_file = format!("{}/{}.preprocessed.rc", out_dir, prefix);
     std::fs::write(&out_file, expanded).unwrap();
 
@@ -57,6 +59,7 @@ fn compile_llvm_rc(rc_exec: &str, out_dir: &str, prefix: &str, resource: &str) {
         .args(&["/fo", &format!("{}/{}.lib", out_dir, prefix)])
         .arg(out_file)
         .stdin(Stdio::piped())
+        .current_dir(resource_dir)
         .status()
         .expect(&format!("Failed to run {}.", rc_exec))
         .success()


### PR DESCRIPTION
This is a bit of a rough draft implementing support for compiling resource files with `llvm-rc`, so we can cross-compile from linux to windows.

Something I noticed is that this crate will not embed the resource file when cross-compiling from linux with the MSVC target.  The build won't fail, but the resulting executable won't have the resource. With this PR, cross-compiling for the windows targets will fail the build if the resource can't be embedded.

Fixes #29 