### PR TITLE
Update winreg to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ cc = "1.0"
 vswhom = "0.1"
 
 [target.'cfg(all(target_os = "windows", target_env = "msvc"))'.dependencies.winreg]
-version = "0.8"
+version = "0.9"
 default-features = false


### PR DESCRIPTION
Trying to reduce version duplications in my project ^^. Updates winreg to the latest release.

The main breaking change is around OsStrings, which were returned null-terminated by previous versions of winreg. Rust-embed-resource only gets Strings from winreg, so it shouldn't be affected.