### PR TITLE
Support for `*-pc-windows-gnullvm`

### DIFF
--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -54,7 +54,7 @@ impl Compiler {
             return Some(guess_compiler_variant(&rc));
         }
 
-        if target.ends_with("-pc-windows-gnu") {
+        if target.ends_with("-pc-windows-gnu") || target.ends_with("-pc-windows-gnullvm") {
             let executable = format!("{}-w64-mingw32-windres", &target[0..target.find('-').unwrap_or_default()]);
             if is_runnable(&executable) {
                 return Some(Compiler {


### PR DESCRIPTION
Those targets use [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) as cross compiler, and have been added to Tier 3 officially.