### PR TITLE
update version of winreg to 0.51.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ cc = "1.0"
 vswhom = "0.1"
 
 [target.'cfg(all(target_os = "windows", target_env = "msvc"))'.dependencies.winreg]
-version = "0.11"
+version = "0.51"
 default-features = false
 
 


### PR DESCRIPTION
Update the version of `winreg` to latest, which eliminates the build dependency on `winapi`.

`cargo test -q` results:

```
running 5 tests
.....
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
```

`cargo tree` output diff:

```
$ diff ../before.txt ../after.txt
25c25
< └── winreg v0.11.0
---
> └── winreg v0.51.0
27c27,29
<     └── winapi v0.3.9
---
>     └── windows-sys v0.48.0
>         └── windows-targets v0.48.5
>             └── windows_x86_64_msvc v0.48.5
```

Further tested by updating `build.rs` for `tray-item`'s `examples/windows` app to use `embed_resource::compile(...)` and verified that the example app properly built with icon embedding.