### PR TITLE
Upgrade `toml` dependency to `0.8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = ["*.enc"]
 
 [dependencies]
 rustc_version = "0.4"
-toml = "0.7"
+toml = "0.8"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 cc = "1.0"


### PR DESCRIPTION
No significant/breaking changes in this release that affect the code implementation, but this is useful to get rid of duplicate dependencies in downstream crates.
