### PR TITLE
Support LLVM17 in llvm-rc auto-detection

### DIFF
--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -147,7 +147,7 @@ fn guess_compiler_variant(s: &str) -> Compiler {
                     executable: s.to_string().into(),
                     tp: CompilerType::WindRes,
                 }
-            } else if out.stdout.starts_with(b"OVERVIEW: Resource Converter") {
+            } else if out.stdout.starts_with(b"OVERVIEW: Resource Converter") || out.stdout.starts_with(b"OVERVIEW: LLVM Resource Converter") {
                 Compiler {
                     executable: s.to_string().into(),
                     tp: CompilerType::LlvmRc,


### PR DESCRIPTION
llvm-rc tweaked the title slightly in `llvm-rc /?` to mention that it's the LLVM variant of rc.