### PR TITLE
fix: use UTF-8 code page when running llvm-rc

### DIFF
--- a/src/non_windows.rs
+++ b/src/non_windows.rs
@@ -108,6 +108,9 @@ impl Compiler {
 
                 try_command(Command::new(&self.executable[..])
                                 .args(&["/fo", &out_file])
+                                // use UTF8 as an encoding
+                                // this makes it easier since in rust all string are UTF8
+                                .args(&["/C", "65001"])
                                 .args(if has_no_preprocess {
                                     // We already preprocessed using CC. llvm-rc preprocessing
                                     // requires having clang in PATH, which more exotic toolchains


### PR DESCRIPTION
I'm using this crate on [tauri-winres](https://github.com/tauri-apps/winres) and we're having trouble with UTF-8 characters in properties. Even though we set the code page using #pragma(https://github.com/tauri-apps/winres/blob/8d0f670102c720de71b284ba795561e5640601e7/src/lib.rs#L411) it is not supported: https://github.com/llvm/llvm-project/issues/63426

I think forcing the code page to 65001 is safe here. Let me know what you think.

See https://github.com/tauri-apps/tauri/issues/12045 for more information.