### PR TITLE
README: Update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following steps are used to embed a manifest in your compiled rust .exe file
 1. Add the following to your cargo.toml:
 ```toml
 [build-dependencies]
-embed-resource = "2.5"
+embed-resource = "3.0"
 ```
 
 2. In your project root directory, add a file named `build.rs` with the following:


### PR DESCRIPTION
Build fails when following the instructions in the README with the example build.rs and resource files.

In 2.5 `embed_resource::compile` returns `()` so we can't call `manifest_optional()` on it.