### PR TITLE
Add include_dirs parameter to embed_resource::compile

### DIFF
--- a/.github/workflows/msvc/build.rs
+++ b/.github/workflows/msvc/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    embed_resource::compile("version.rc", embed_resource::NONE).manifest_required().unwrap();
+    embed_resource::compile("version.rc", embed_resource::NONE, embed_resource::NONE).manifest_required().unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,6 @@ fn main() {
     env::set_var("OUT_DIR", ".");
 
     let resource = env::args().nth(1).expect("Specify the resource file to be compiled as the first argument.");
-    embed_resource::compile(&resource, &["VERSION=\"0.5.0\""]).manifest_required().unwrap();
-    embed_resource::compile_for(&resource, &["embed_resource", "embed_resource-installer"], embed_resource::NONE).manifest_required().unwrap();
+    embed_resource::compile(&resource, ["VERSION=\"0.5.0\""], embed_resource::NONE).manifest_required().unwrap();
+    embed_resource::compile_for(&resource, ["embed_resource", "embed_resource-installer"], embed_resource::NONE, embed_resource::NONE).manifest_required().unwrap();
 }


### PR DESCRIPTION
This is a breaking change.

I added the `include_dirs` parameter to `embed_resource::compile` so that additional header file paths can be passed to `rc.exe` or `windres.exe`.

In my case, my `rc` file looks like this:
```
#include <windows.h>

#include "wx/msw/rcdefs.h"

wxWindowMenu MENU DISCARDABLE
BEGIN
    POPUP "&Window"
    BEGIN
        MENUITEM "&Cascade",                    4002
        MENUITEM "Tile &Horizontally",          4001
        MENUITEM "Tile &Vertically",            4005
        MENUITEM "",                            -1
        MENUITEM "&Arrange Icons",              4003
        MENUITEM "&Next",                       4004
    END
END

WXCURSOR_HAND           CURSOR  DISCARDABLE     "wx/msw/hand.cur"
WXCURSOR_BULLSEYE       CURSOR  DISCARDABLE     "wx/msw/bullseye.cur"

...
```
I had to specify a search path for the include file `wx/msw/rcdefs.h`. This isn't a problem for `rc.exe`, we can simply add an `INCLUDE` environment variable to it. However, this method doesn't work if the resource compiler is `windres.exe`, so I added `include_dirs` to the `embed_resource::compile` function.

This PR also test passed on macOS & Linux.

I really hope you can merge this PR and release a major version.
