### PR TITLE
Use llvm-rc on aarch64-gnullvm

### DIFF
--- a/src/windows_not_msvc.rs
+++ b/src/windows_not_msvc.rs
@@ -26,10 +26,14 @@ impl ResourceCompiler {
         -> Result<String, Cow<'static, str>> {
         let out_file = format!("{}{}lib{}.a", out_dir, MAIN_SEPARATOR, prefix);
 
+        let target = env::var("TARGET").expect("No TARGET env var");
+        let is_gnullvm = target.ends_with("-gnullvm");
+        let is_aarch64 = target.starts_with("aarch64-");
+
         // Under some msys2 environments, $MINGW_CHOST has the correct target for
         // GNU windres or llvm-windres (clang32, clang64, or clangarm64)
         let target = env::var_os("MINGW_CHOST").map(Cow::Owned).unwrap_or_else(|| {
-            OsStr::new(match env::var_os("TARGET").expect("No TARGET env var").as_encoded_bytes() {
+            OsStr::new(match target.as_bytes() {
                     [b'x', b'8', b'6', b'_', b'6', b'4', ..] => "pe-x86-64", // "x86_64"
                     [b'a', b'a', b'r', b'c', b'h', b'6', b'4', ..] => "pe-aarch64-little", // "aarch64"
                     // windres has "pe-aarch64-little" in the strings but doesn't actually accept it on my machine,
@@ -39,18 +43,27 @@ impl ResourceCompiler {
                 .into()
         });
 
-        match apply_parameters(Command::new("windres")
-                                   .args(&["--input", resource, "--output-format=coff", "--target"])
-                                   .arg(target)
-                                   .args(&["-c", "65001"]) // UTF-8, cf. https://github.com/nabijaczleweli/rust-embed-resource/pull/73
-                                   .args(&["--output", &out_file, "--include-dir", out_dir]),
-                               "-D",
-                               "-I",
-                               parameters)
-            .status() {
+        let exe_name = if is_gnullvm && is_aarch64 {
+            // https://github.com/llvm/llvm-project/issues/125371
+            "llvm-rc"
+        } else {
+            "windres"
+        };
+
+        let mut command = Command::new(exe_name);
+        if is_gnullvm && is_aarch64 {
+            command.args(&["-fo", &out_file, "-I", out_dir, resource]);
+        } else {
+            command.args(&["--input", resource, "--output-format=coff", "--target"])
+                .arg(target)
+                .args(&["-c", "65001"]) // UTF-8, cf. https://github.com/nabijaczleweli/rust-embed-resource/pull/73
+                .args(&["--output", &out_file, "--include-dir", out_dir]);
+        }
+
+        match apply_parameters(&mut command, "-D", "-I", parameters).status() {
             Ok(stat) if stat.success() => Ok(out_file),
-            Ok(stat) => Err(format!("windres failed to compile \"{}\" into \"{}\" with {}", resource, out_file, stat).into()),
-            Err(e) => Err(format!("Couldn't to execute windres to compile \"{}\" into \"{}\": {}", resource, out_file, e).into()),
+            Ok(stat) => Err(format!("{} failed to compile \"{}\" into \"{}\" with {}", exe_name, resource, out_file, stat).into()),
+            Err(e) => Err(format!("Couldn't to execute {} to compile \"{}\" into \"{}\": {}", exe_name, resource, out_file, e).into()),
         }
     }
 }


### PR DESCRIPTION
The llvm `windres` doesn't support `pe-aarch64-little`, but `llvm-rc` actually works well.